### PR TITLE
Add initial MCP plugin skeleton

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/README.md
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/README.md
@@ -1,0 +1,4 @@
+# OpenC3 COSMOS MCP Plugin
+
+This plugin exposes a microservice implementing the Mission Control Protocol (MCP).
+It forwards MCP requests to the existing JSON API.

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/Rakefile
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/Rakefile
@@ -1,0 +1,1 @@
+# Placeholder Rakefile for MCP plugin

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/microservices/mcp_service.rb
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/microservices/mcp_service.rb
@@ -1,0 +1,1 @@
+# TODO: Implement MCP service

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/openc3-cosmos-mcp.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/openc3-cosmos-mcp.gemspec
@@ -1,0 +1,8 @@
+# encoding: ascii-8bit
+Gem::Specification.new do |s|
+  s.name = 'openc3-cosmos-mcp'
+  s.summary = 'OpenC3 COSMOS MCP Microservice'
+  s.authors = ['OpenC3']
+  s.version = '0.0.0'
+  s.files = %w(plugin.txt README.md Rakefile)
+end

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/plugin.txt
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/plugin.txt
@@ -1,0 +1,4 @@
+MICROSERVICE MCP <%= mcp_service_name %>
+  CMD ruby mcp_service.rb
+  ROUTE_PREFIX /mcp
+  PORT 7660


### PR DESCRIPTION
## Summary
- scaffold new openc3-cosmos-mcp plugin
- add plugin.txt defining MCP microservice
- include minimal gemspec, README, and Rakefile

## Testing
- `bundle exec rake spec` *(fails: Could not find gem 'benchmark-ips (~> 2.9)' in locally installed gems)*