### PR TITLE
Add MCP microservice

### DIFF
--- a/docs.openc3.com/docs/development/mcp-integration-design.md
+++ b/docs.openc3.com/docs/development/mcp-integration-design.md
@@ -22,11 +22,10 @@ OpenC3 COSMOS already exposes JSON-RPC and WebSocket streaming APIs. To support 
 
 These libraries should be included in the plugin's Gem or Python requirements file so they are installed when the plugin is built.
 
-## TODO
+## Status
 
-1. Prototype a plugin with a basic MCP microservice that authenticates via COSMOS.
-2. Map MCP operations to JSON API calls for commands and telemetry retrieval.
-3. Add streaming support by forwarding telemetry updates from the WebSocket API to MCP clients.
-4. Provide configuration options for ROUTE_PREFIX and service port.
-5. Document how to install and run the plugin.
+The initial MCP adapter has been implemented as a plugin microservice. It uses
+`AuthModel` for token validation and exposes HTTP endpoints for sending commands
+and retrieving telemetry. Future work includes streaming telemetry support and
+additional MCP message types.
 

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/README.md
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/README.md
@@ -1,4 +1,18 @@
 # OpenC3 COSMOS MCP Plugin
 
 This plugin exposes a microservice implementing the Mission Control Protocol (MCP).
-It forwards MCP requests to the existing JSON API.
+The microservice provides a lightweight HTTP adapter that translates MCP style
+requests into COSMOS API calls.
+
+### Endpoints
+
+```
+POST /mcp/cmd
+  {"token":"TOKEN","target":"TGT","command":"CMD","params":{}}
+
+GET  /mcp/tlm?token=TOKEN&target=TGT&packet=PKT&item=ITEM
+```
+
+Both endpoints require a valid COSMOS token which is verified using
+`AuthModel`. The adapter can be configured through `plugin.txt` to run on a
+specific port and route prefix.

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/microservices/mcp_service.rb
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/microservices/mcp_service.rb
@@ -1,1 +1,105 @@
-# TODO: Implement MCP service
+# encoding: ascii-8bit
+
+# Minimal Mission Control Protocol microservice. This service exposes a very
+# small HTTP API which translates MCP style requests into existing COSMOS API
+# calls. It supports sending commands and retrieving telemetry using the
+# existing API helper methods. Authentication is performed using AuthModel so a
+# valid COSMOS token must be supplied with each request.
+
+require 'openc3/microservices/microservice'
+require 'openc3/api/api'
+require 'openc3/models/auth_model'
+require 'webrick'
+require 'json'
+
+module OpenC3
+  # Simple HTTP based MCP adapter. It listens for JSON encoded MCP requests on
+  # a configurable port and forwards them to the COSMOS API.
+  class McpMicroservice < Microservice
+    include Api
+
+    def initialize(name)
+      super(name)
+
+      @port = (@config['port'] || ENV['MCP_PORT'] || 7660).to_i
+      @route_prefix = @config['route_prefix'] || '/mcp'
+      @server = nil
+    end
+
+    # Start the WEBrick HTTP server and mount the MCP endpoints.
+    def run
+      @server = WEBrick::HTTPServer.new(:Port => @port, :BindAddress => '0.0.0.0')
+      @logger.info("MCP service listening on port #{@port}")
+
+      @server.mount_proc(File.join(@route_prefix, 'cmd')) do |req, res|
+        handle_cmd(req, res)
+      end
+
+      @server.mount_proc(File.join(@route_prefix, 'tlm')) do |req, res|
+        handle_tlm(req, res)
+      end
+
+      trap('INT') { @server.shutdown }
+      trap('TERM') { @server.shutdown }
+      @server.start
+    end
+
+    # Handle a command request. Expects JSON of the form:
+    #   {"token":"...","target":"TGT","command":"CMD","params":{...}}
+    def handle_cmd(req, res)
+      data = parse_request(req, res)
+      return unless data
+
+      cmd(data['target'], data['command'], **(data['params'] || {}))
+      res.body = {status: 'OK'}.to_json
+    rescue => err
+      @logger.error("MCP command error: #{err.formatted}")
+      res.status = 500
+      res.body = {error: err.message}.to_json
+    end
+
+    # Handle telemetry requests. Query parameters should contain 'target',
+    # 'packet' and 'item'.
+    def handle_tlm(req, res)
+      data = parse_request(req, res, query: true)
+      return unless data
+
+      value = tlm(data['target'], data['packet'], data['item'])
+      res.body = {status: 'OK', value: value}.to_json
+    rescue => err
+      @logger.error("MCP telemetry error: #{err.formatted}")
+      res.status = 500
+      res.body = {error: err.message}.to_json
+    end
+
+    # Parse the request body or query string and verify authentication token.
+    def parse_request(req, res, query: false)
+      token = req.header['x-cosmos-token']&.first || req.query['token']
+      unless OpenC3::AuthModel.verify(token)
+        res.status = 401
+        res.body = {error: 'Unauthorized'}.to_json
+        return nil
+      end
+
+      if query
+        return req.query
+      else
+        begin
+          return JSON.parse(req.body)
+        rescue JSON::ParserError => e
+          res.status = 400
+          res.body = {error: 'Invalid JSON'}.to_json
+          return nil
+        end
+      end
+    end
+
+    def shutdown(state = 'STOPPED')
+      @server&.shutdown
+      super(state)
+    end
+  end
+end
+
+OpenC3::McpMicroservice.run if __FILE__ == $0
+

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/openc3-cosmos-mcp.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-mcp/openc3-cosmos-mcp.gemspec
@@ -4,5 +4,5 @@ Gem::Specification.new do |s|
   s.summary = 'OpenC3 COSMOS MCP Microservice'
   s.authors = ['OpenC3']
   s.version = '0.0.0'
-  s.files = %w(plugin.txt README.md Rakefile)
+  s.files = Dir.glob('microservices/**/*') + %w(plugin.txt README.md Rakefile)
 end


### PR DESCRIPTION
## Summary
- add a basic Mission Control Protocol microservice
- document MCP endpoints and mark design doc as implemented
- package microservice in the MCP gem

## Testing
- `./scripts/linux/openc3_test.sh rspec` *(fails: docker: command not found)*